### PR TITLE
Enhancement/#20 add currency code in string xml

### DIFF
--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -42,6 +42,50 @@
         <item>Наименование</item>
         <item>Код</item>
     </string-array>
+    <string-array name="currency_names">
+        <item>Дирхам на ОАЕ (Арабски дирхам)</item>
+        <item>Албански лек</item>
+        <item>Австралийски долар</item>
+        <item>Конвертабилна марка на Босна и Херцеговина</item>
+        <item>Бразилски реал</item>
+        <item>Канадски долар</item>
+        <item>Швейцарски франк</item>
+        <item>Китайски юан</item>
+        <item>Чешка крона</item>
+        <item>Датска крона</item>
+        <item>Доминиканско песо</item>
+        <item>стонска крона</item>
+        <item>Египетска лира</item>
+        <item>Евро</item>
+        <item>Британска лира</item>
+        <item>Хонгконгски долар</item>
+        <item>Хърватска куна</item>
+        <item>Унгарски форинт</item>
+        <item>Индонезийска рупия</item>
+        <item>Израелски шекел</item>
+        <item>Японска йена</item>
+        <item>Кенийски шилинг</item>
+        <item>Южнокорейски вон</item>
+        <item>Литовски литас</item>
+        <item>Латвийски лат</item>
+        <item>Македонски денар</item>
+        <item>Мавританска рупия</item>
+        <item>Мексиканско песо</item>
+        <item>Малайзийски рингит</item>
+        <item>Норвежка крона</item>
+        <item>Новозеландски долар</item>
+        <item>Полска злота</item>
+        <item>Румънска лея</item>
+        <item>Сръбски динар</item>
+        <item>Руска рубла</item>
+        <item>Шведска крона</item>
+        <item>Сингапурски долар</item>
+        <item>Тайландски бат</item>
+        <item>Нова турска лира</item>
+        <item>Украинска гривна</item>
+        <item>Щатски долар</item>
+        <item>Южноафрикански ранд</item>
+    </string-array>
     <string name="action_filter">Филтър</string>
     <string name="action_filter_title">Показване на</string>
     <string name="action_filter_fixed">Фиксирани курсове</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -42,6 +42,94 @@
         <item>Name</item>
         <item>Code</item>
     </string-array>
+    <string-array name="currency_codes">
+        <item>AED</item>
+        <item>ALL</item>
+        <item>AUD</item>
+        <item>BAM</item>
+        <item>BRL</item>
+        <item>CAD</item>
+        <item>CHF</item>
+        <item>CNY</item>
+        <item>CZK</item>
+        <item>DKK</item>
+        <item>DOP</item>
+        <item>EEK</item>
+        <item>EGP</item>
+        <item>EUR</item>
+        <item>GBP</item>
+        <item>HKD</item>
+        <item>HRK</item>
+        <item>HUF</item>
+        <item>IDR</item>
+        <item>ILS</item>
+        <item>JPY</item>
+        <item>KES</item>
+        <item>KRW</item>
+        <item>LTL</item>
+        <item>LVL</item>
+        <item>MKD</item>
+        <item>MUR</item>
+        <item>MXN</item>
+        <item>MYR</item>
+        <item>NOK</item>
+        <item>NZD</item>
+        <item>PLN</item>
+        <item>RON</item>
+        <item>RSD</item>
+        <item>RUB</item>
+        <item>SEK</item>
+        <item>SGD</item>
+        <item>THB</item>
+        <item>TRY</item>
+        <item>UAH</item>
+        <item>USD</item>
+        <item>ZAR</item>
+    </string-array>
+    <string-array name="currency_names">
+        <item>United Arab Emirates dirham</item>
+        <item>Albanian lek</item>
+        <item>Australian dollar</item>
+        <item>Bosnia and Herzegovina convertible mark</item>
+        <item>Brazilian real</item>
+        <item>Canadian dollar</item>
+        <item>Swiss franc</item>
+        <item>Chinese yuan</item>
+        <item>Czech koruna</item>
+        <item>Danish krone</item>
+        <item>Dominican peso</item>
+        <item>Estonian kroon</item>
+        <item>Egyptian pound</item>
+        <item>Euro</item>
+        <item>Pound sterling</item>
+        <item>Hong Kong dollar</item>
+        <item>Croatian kuna</item>
+        <item>Hungarian forint</item>
+        <item>Indonesian rupiah</item>
+        <item>Israeli new shekel</item>
+        <item>Japanese yen</item>
+        <item>Kenyan shilling</item>
+        <item>South Korean won</item>
+        <item>Lithuanian litas</item>
+        <item>Latvian lats</item>
+        <item>Macedonian denar</item>
+        <item>Mauritian rupee</item>
+        <item>Mexican peso</item>
+        <item>Malaysian ringgit</item>
+        <item>Norwegian krone</item>
+        <item>New Zealand dollar</item>
+        <item>Polish złoty</item>
+        <item>Romanian leu</item>
+        <item>Serbian dinar</item>
+        <item>Russian ruble</item>
+        <item>Swedish krona/kronor</item>
+        <item>Singapore dollar</item>
+        <item>Thai baht</item>
+        <item>Turkish lira</item>
+        <item>Ukrainian hryvnia</item>
+        <item>United States dollar</item>
+        <item>South African rand</item>
+    </string-array>
     <string name="action_filter">Filter</string>
     <string name="action_filter_title">Show currency rates</string>
     <string name="action_filter_fixed">Fixed rates</string>

--- a/src/main/java/net/vexelon/currencybg/app/db/CurrenciesSQLiteDB.java
+++ b/src/main/java/net/vexelon/currencybg/app/db/CurrenciesSQLiteDB.java
@@ -58,6 +58,11 @@ public class CurrenciesSQLiteDB extends SQLiteOpenHelper {
 			 */
 			database.execSQL(CREATE_TABLE_CURRENCY_BG);
 			// TODO - drop old tables if exists
+			/*
+			*try{
+			* drop the old tables
+			* catch
+			 */
 			break;
 		default:
 			Log.w(Defs.LOG_TAG, "Unknown old db version=" + oldVersion);


### PR DESCRIPTION
Кодовете на валутите + имената и са добавени в string.xml файловете. Не е добавена само "**SBP**", за която имахме дискусия по email. Мето предложи да не я добавяме. Предлагам на следващата среща да го дискутираме и да решим какво ще правим, ако ще я добавяме ще я въведа с друг бранч.