### PR TITLE
Fix manual and service based currency updates

### DIFF
--- a/src/main/java/net/vexelon/currencybg/app/db/DataSource.java
+++ b/src/main/java/net/vexelon/currencybg/app/db/DataSource.java
@@ -19,7 +19,11 @@ package net.vexelon.currencybg.app.db;
 
 import android.content.Context;
 
+import com.google.common.base.Optional;
+
 import net.vexelon.currencybg.app.db.models.CurrencyData;
+
+import org.joda.time.DateTime;
 
 import java.io.Closeable;
 import java.util.List;
@@ -86,10 +90,18 @@ public interface DataSource extends Closeable {
 	public List<CurrencyData> getAllRates(String code) throws DataSourceException;
 
 	/**
-	 * Delete all rates older than {@code backDays}.
+	 * Deletes all rates older than {@code backDays}.
 	 *
 	 * @param backDays
 	 * @throws DataSourceException
 	 */
 	public void deleteRates(int backDays) throws DataSourceException;
+
+	/**
+	 * Finds the latest download time among all currencies that currently exist
+	 * in the database.
+	 * 
+	 * @return
+	 */
+	public Optional<DateTime> getLastRatesDownloadTime() throws DataSourceException;
 }

--- a/src/main/java/net/vexelon/currencybg/app/services/BackgroundService.java
+++ b/src/main/java/net/vexelon/currencybg/app/services/BackgroundService.java
@@ -92,16 +92,19 @@ public class BackgroundService extends Service {
 			List<CurrencyData> currencies = Lists.newArrayList();
 
 			try {
-				String iso8601Time = lastUpdate.toString();
-				Log.d(Defs.LOG_TAG, "[Service] Downloading all rates since " + iso8601Time + " onwards...");
-
-				// format, e.g., "2016-11-09T01:00:06+03:00"
-				currencies = new APISource().getAllCurrentRatesAfter(iso8601Time);
-
 				source = new SQLiteDataSource();
 				source.connect(BackgroundService.this);
-				source.addRates(currencies);
 
+				// the service always fetches all currencies for the current day
+				// format, e.g., "2016-11-09T00:00:00+02:00"
+				DateTime from = DateTime.now(DateTimeZone.forTimeZone(TimeZone.getTimeZone(Defs.DATE_TIMEZONE_SOFIA)))
+						.withTime(0, 0, 0, 0);
+				String iso8601Time = from.toString();
+
+				Log.d(Defs.LOG_TAG, "[Service] Downloading all rates since " + iso8601Time + " ...");
+
+				currencies = new APISource().getAllCurrentRatesAfter(iso8601Time);
+				source.addRates(currencies);
 				updateOK = true;
 
 				Log.d(Defs.LOG_TAG, "[Service] Cleaning up currency rates older than 3 days ...");


### PR DESCRIPTION
Преправен е малко update-a на валутите, тъй като нещо не работеше както трябва. Предната логика не намираше валути с дата/час по-малки от дата/часа на последния update в приложението, в резултат на което липсваха част от записите в базата.

- Сървисът в момента винаги дърпа всички валути от 00:00 часа за текущия ден.
- Ръчният update дърпа или с последната дата на валутите в базата или от 00:00 часа за текущия ден. 

-----

The background service will always fetch all currencies for the day. It does that 3-4 times a day.

The manual update will fetch the latest currency date from the database use that as an date time offset for the update.
If the latest currency date is older than the current date, then the beginning of the current day will be used as
an offset date for the update.
