### PR TITLE
Feature/#90 sql optimize

### DIFF
--- a/src/main/java/net/vexelon/currencybg/app/ui/fragments/CurrenciesFragment.java
+++ b/src/main/java/net/vexelon/currencybg/app/ui/fragments/CurrenciesFragment.java
@@ -111,7 +111,7 @@ public class CurrenciesFragment extends AbstractFragment implements LoadListener
 
 	@Override
 	public void onResume() {
-		new ReloadRatesTask(getActivity(), this, false).execute();
+		reloadCurrencies(getActivity(), false, true);
 		super.onResume();
 	}
 
@@ -244,7 +244,7 @@ public class CurrenciesFragment extends AbstractFragment implements LoadListener
 
 								showSnackbar(getResources().getString(R.string.action_filter_desc, text));
 
-								reloadCurrencies(activity, false, true);
+								updateCurrenciesListView(activity, rates);
 								return true;
 
 							case CUSTOM_INDEX: // AppSettings.CURRENCY_FILTER_CUSTOM
@@ -289,7 +289,7 @@ public class CurrenciesFragment extends AbstractFragment implements LoadListener
 						showSnackbar(getResources().getString(R.string.action_filter_desc,
 								getResources().getString(R.string.action_filter_custom)));
 
-						reloadCurrencies(activity, false, true);
+						updateCurrenciesListView(activity, rates);
 					}
 				}).build();
 	}

--- a/src/main/java/net/vexelon/currencybg/app/utils/NumberUtils.java
+++ b/src/main/java/net/vexelon/currencybg/app/utils/NumberUtils.java
@@ -99,7 +99,9 @@ public final class NumberUtils {
 				format.setCurrency(currency);
 				return new BigDecimal(format.parse(formattedCurrency).toString());
 			} catch (IllegalArgumentException e) {
-				Log.wtf(Defs.LOG_TAG, "Died at currency to bign - " + formattedCurrency, e);
+				// Log.wtf(Defs.LOG_TAG, "Died at currency to bign - " + formattedCurrency, e);
+				Log.d(Defs.LOG_TAG, "Error formatting currency! Unknown currency code - " + code);
+				return new BigDecimal(formattedCurrency);
 			} catch (ParseException e) {
 				Log.wtf(Defs.LOG_TAG, "Died at currency to bign parse - " + formattedCurrency, e);
 			}


### PR DESCRIPTION
Малки оптимизации в `getLastRates()`. При мен, при близо 17-20 хиляди реда в SQLite таблицата на приложението, има осезаемо забавяне от около 2-3 секунди при зареждане на валутите във фрагментите. 

Главно при `cursor.getColumnIndex()` има доста забавяне, затова сега се ползва cache map, за да вземе индексите на колоните. При `getLastRates()` съм сложил и `LIMIT 5000`, което не е най-добрата идея, но за момента ще свърши работа. 

За в бъдеще, ще трябва по-бърз и надежден начин да вземаме най-новите валутни курсове за източници и валути от базата.

Ref #90 